### PR TITLE
Catch Buzz exception so we don't leak them outside our library

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -70,7 +70,11 @@ class Client
 
         $headers = array("Authorization" => $this->auth->getCredential());
 
-        $response = $this->browser->get($url, $headers);
+        try {
+            $response = $this->browser->get($url, $headers);
+        } catch (\Buzz\Exception\ClientException $e) {
+            throw new RequestException($e->getMessage());
+        }
 
         if ($this->browser->getLastResponse()->getStatusCode() > 299) {
             throw new RequestException(json_decode($this->browser->getLastResponse()->getContent(), true));
@@ -104,7 +108,11 @@ class Client
             'Authorization' => $this->auth->getCredential()
         );
 
-        $response = $this->browser->post($url, $headers, json_encode($content));
+        try {
+            $response = $this->browser->post($url, $headers, json_encode($content));
+        } catch (\Buzz\Exception\ClientException $e) {
+            throw new RequestException($e->getMessage());
+        }
 
         if ($this->browser->getLastResponse()->getStatusCode() > 299) {
             throw new RequestException(json_decode($this->browser->getLastResponse()->getContent(), true));
@@ -137,7 +145,11 @@ class Client
             'Authorization' => $this->auth->getCredential()
         );
 
-        $response = $this->browser->put($url, $headers, json_encode($content));
+        try {
+            $response = $this->browser->put($url, $headers, json_encode($content));
+        } catch (\Buzz\Exception\ClientException $e) {
+            throw new RequestException($e->getMessage());
+        }
 
         if ($this->browser->getLastResponse()->getStatusCode() > 299) {
             throw new RequestException(json_decode($this->browser->getLastResponse()->getContent(), true));
@@ -162,7 +174,11 @@ class Client
             'Authorization' => $this->auth->getCredential()
         );
 
-        $response = $this->browser->delete($url, $headers);
+        try {
+            $response = $this->browser->delete($url, $headers);
+        } catch (\Buzz\Exception\ClientException $e) {
+            throw new RequestException($e->getMessage());
+        }
 
         if ($this->browser->getLastResponse()->getStatusCode() > 299) {
             throw new RequestException(json_decode($this->browser->getLastResponse()->getContent(), true));


### PR DESCRIPTION
Buzz is leaking exception in case of connect timeout of any error. We wrap these correctly so that higher up they don't need to worry about the client used.