### PR TITLE
Make from in message mutable

### DIFF
--- a/Model/Message.php
+++ b/Model/Message.php
@@ -5,7 +5,7 @@ namespace GorkaLaucirica\HipchatAPIv2Client\Model;
 class Message
 {
 
-    protected $id = null;
+    protected $id;
 
     protected $color;
 
@@ -15,9 +15,9 @@ class Message
 
     protected $messageFormat;
 
-    protected $date = null;
+    protected $date;
 
-    protected $from = null;
+    protected $from;
 
 
     const COLOR_YELLOW = 'yellow';
@@ -42,6 +42,7 @@ class Message
             $this->messageFormat = self::FORMAT_HTML;
             $this->message = "";
             $this->notify = false;
+            $this->from = "";
         }
     }
 
@@ -167,5 +168,28 @@ class Message
     public function getMessageFormat()
     {
         return $this->messageFormat;
+    }
+
+    /**
+     * Sets a label to be shown in addition to the sender's name
+     *
+     * @param string $from A label to be shown in addition to the sender's name
+     *
+     * @return self
+     */
+    public function setFrom($from)
+    {
+        $this->from = $from;
+        return $this;
+    }
+
+    /**
+     * Returns how the message is treated by the server and rendered inside HipChat applications
+     *
+     * @return string
+     */
+    public function getFrom()
+    {
+        return $this->from;
     }
 }

--- a/spec/GorkaLaucirica/HipchatAPIv2Client/Model/MessageSpec.php
+++ b/spec/GorkaLaucirica/HipchatAPIv2Client/Model/MessageSpec.php
@@ -31,7 +31,7 @@ class MessageSpec extends ObjectBehavior
         $this->setColor(Message::COLOR_GRAY);
         $this->setMessage('This is a test!!');
         $this->toJson()->shouldReturn(
-            array("id" => null, "from" => null, "color" => "gray", "message" => "This is a test!!", 'notify' => false, 'message_format' => 'html', 'date' => null)
+            array("id" => null, "from" => '', "color" => "gray", "message" => "This is a test!!", 'notify' => false, 'message_format' => 'html', 'date' => null)
         );
     }
 
@@ -57,5 +57,11 @@ class MessageSpec extends ObjectBehavior
     {
         $this->setMessageFormat(Message::FORMAT_TEXT)->shouldReturn($this);
         $this->getMessageFormat()->shouldReturn(Message::FORMAT_TEXT);
+    }
+
+    function its_from_is_mutable()
+    {
+        $this->setFrom('test from')->shouldReturn($this);
+        $this->getFrom()->shouldReturn('test from');
     }
 }


### PR DESCRIPTION
Seems like hipchat had a recent api change - I'm getting a "Value None for field 'from' is not of type 'string'" error when sending a message to a room.
This PR makes from mutable, and sets it to an empty string for a new message.