### PR TITLE
Message "from" can't be null

### DIFF
--- a/Model/Message.php
+++ b/Model/Message.php
@@ -17,7 +17,7 @@ class Message
 
     protected $date = null;
 
-    protected $from = null;
+    protected $from = '';
 
 
     const COLOR_YELLOW = 'yellow';
@@ -167,5 +167,28 @@ class Message
     public function getMessageFormat()
     {
         return $this->messageFormat;
+    }
+	
+	/**
+     * Sets a label to be shown in addition to the sender's name
+     *
+     * @param string $from The label
+     *
+     * @return self
+     */
+    public function setFrom($from)
+    {
+        $this->from = $from;
+        return $this;
+    }
+
+    /**
+     * Gets the label to be shown in addition to the sender's name
+     *
+     * @return string|array
+     */
+    public function getFrom()
+    {
+        return $this->from;
     }
 }

--- a/Model/Message.php
+++ b/Model/Message.php
@@ -168,8 +168,8 @@ class Message
     {
         return $this->messageFormat;
     }
-	
-	/**
+
+    /**
      * Sets a label to be shown in addition to the sender's name
      *
      * @param string $from The label


### PR DESCRIPTION
Because of [this](https://www.apichangelog.com/changes/3f30140d-066b-4345-9050-c124f32369a3#first-change) API change, the 'from' attribute of the message can't be null. Changing it's default value to an empty string. Added getter and setter.