### PR TITLE
Updated sendRoomNotification method to support rooms with spaces in name

### DIFF
--- a/API/RoomAPI.php
+++ b/API/RoomAPI.php
@@ -129,6 +129,7 @@ class RoomAPI
      */
     public function sendRoomNotification($id, Message $message)
     {
+        $id = rawurlencode($id);
         $this->client->post("/v2/room/$id/notification", $message->toJson());
     }
 


### PR DESCRIPTION
Rooms with spaces in their names are not supported right now. Here's a fix.

Other methods will need that update too. I'll do it when this PR gets accepted.