### PR TITLE
Add basic support for Message Cards

### DIFF
--- a/Model/Card.php
+++ b/Model/Card.php
@@ -7,7 +7,18 @@
 
 namespace GorkaLaucirica\HipchatAPIv2Client\Model;
 
-
+/**
+ * Class Card
+ *
+ * Allows you to send a Card format message rather than a plain text/only-html message.
+ *
+ * Some Hipchat clients may not support Cards, you must still include a `message` property in your Message.
+ *
+ * More Info: https://developer.atlassian.com/hipchat/guide/sending-messages#SendingMessages-UsingCards
+ * Even More Info: https://www.hipchat.com/docs/apiv2/method/send_room_notification
+ *
+ * @package GorkaLaucirica\HipchatAPIv2Client\Model
+ */
 class Card
 {
     /**
@@ -61,6 +72,21 @@ class Card
      * @var CardImage $images
      */
     protected $images;
+
+    /**
+     * Card constructor.
+     *
+     * @param CardStyle $style Style of the Card to use
+     * @param string $description
+     * @param string $title
+     */
+    public function __construct($title, $style, $description)
+    {
+        $this->title = $title;
+        $this->style = $style;
+        $this->description = $description;
+        $this->id = md5($title.$description);
+    }
 
     /**
      * @return CardStyle
@@ -249,7 +275,7 @@ class Card
         if ($this->url) $result['url'] = $this->url;
         if ($this->title) $result['title'] = $this->title;
         if ($this->thumbnail) $result['thumbnail'] = $this->thumbnail->toArray();
-        if ($this->activity) $result['activity'] = $this->activity;
+        if ($this->activity) $result['activity'] = $this->activity->toArray();
         if ($this->attributes) {
             $result['attributes'] = array();
             foreach ($this->attributes as $attribute) {
@@ -266,13 +292,26 @@ class Card
 
 class CardImage {
     /**
-     * @var string $image Image url
+     * @var string $url Image URL
+     * @var string $url2x Image URL for the icon on retina
      */
-    public $image;
+    public $url;
+    public $urlat2;
+
+    /**
+     * CardImage constructor.
+     *
+     * @param string $url Image URL
+     */
+    public function __construct($url)
+    {
+        $this->url = $url;
+    }
 
     public function toArray(){
         $result = array();
-        if ($this->image) $result['image'] = $this->image;
+        if ($this->url) $result['url'] = $this->url;
+        if ($this->urlat2) $result['url@2x'] = $this->urlat2;
         return $result;
     }
 }
@@ -285,14 +324,19 @@ class CardAttribute {
     public $value;
     public $label;
 
-    public function __construct()
+    /**
+     * CardAttribute constructor.
+     *
+     * @param string $value Value for the attribute
+     */
+    public function __construct($value)
     {
-        $this->value = new CardAttributeValue();
+        $this->value = new CardAttributeValue($value);
     }
 
     public function toArray(){
         $result = array();
-        if ($this->value) $result['value'] = $this->value;
+        if ($this->value) $result['value'] = $this->value->toArray();
         if ($this->label) $result['label'] = $this->label;
         return $result;
     }
@@ -301,14 +345,24 @@ class CardAttribute {
 class CardAttributeValue {
     /**
      * @var string $url Url to be opened when a user clicks on the label. Valid length range: 1 - unlimited.
-     * @var AttributeValueStyle $style
-     * @var string $label
+     * @var AttributeValueStyle $style AUI Integrations for now supporting only lozenges
+     * @var string $label The text representation of the value @required
      * @var CardIcon $icon
      */
     public $url;
     public $style;
     public $label;
     public $icon;
+
+    /**
+     * CardAttributeValue constructor.
+     *
+     * @param string $label The text representation of the value
+     */
+    public function __construct($label)
+    {
+        $this->label = $label;
+    }
 
     public function toArray(){
         $result = array();
@@ -321,7 +375,7 @@ class CardAttributeValue {
 }
 
 /**
- * The activity will generate a collapsable card of one line showing
+ * The activity will generate a collapsible card of one line showing
  * the html and the ability to maximize to see all the content.
  *
  * @package GorkaLaucirica\HipchatAPIv2Client\Model
@@ -335,10 +389,20 @@ class CardActivity {
     public $html;
     public $icon;
 
+    /**
+     * CardActivity constructor.
+     *
+     * @param string $html Html for the activity to show in one line a summary of the action that happened
+     */
+    public function __construct($html)
+    {
+        $this->html = $html;
+    }
+
     public function toArray(){
         $result = array();
         if ($this->html) $result['html'] = $this->html;
-        if ($this->icon) $result['icon'] = $this->icon;
+        if ($this->icon) $result['icon'] = $this->icon->toArray();
         return $result;
     }
 }
@@ -355,10 +419,20 @@ class CardIcon {
     public $url;
     public $urlat2;
 
+    /**
+     * CardIcon constructor.
+     *
+     * @param string $url The URL for the icon
+     */
+    public function __construct($url)
+    {
+        $this->url = $url;
+    }
+
     public function toArray(){
         $result = array();
         if ($this->url) $result['url'] = $this->url;
-        if ($this->urlat2) $result['urlat2'] = $this->urlat2;
+        if ($this->urlat2) $result['url@2x'] = $this->urlat2;
         return $result;
     }
 }
@@ -379,11 +453,21 @@ class CardThumbnail {
     public $urlat2;
     public $height;
 
+    /**
+     * CardThumbnail constructor.
+     *
+     * @param string $url The URL for the thumbnail
+     */
+    public function __construct($url)
+    {
+        $this->url = $url;
+    }
+
     public function toArray(){
         $result = array();
-        if ($this->url) $result['value'] = $this->url;
+        if ($this->url) $result['url'] = $this->url;
         if ($this->width) $result['width'] = $this->width;
-        if ($this->urlat2) $result['urlat2'] = $this->urlat2;
+        if ($this->urlat2) $result['url@2x'] = $this->urlat2;
         if ($this->height) $result['height'] = $this->height;
         return $result;
     }

--- a/Model/Card.php
+++ b/Model/Card.php
@@ -1,0 +1,412 @@
+<?php
+/**
+ * User: chipwasson
+ * Date: 1/25/17
+ * Time: 6:47 PM
+ */
+
+namespace GorkaLaucirica\HipchatAPIv2Client\Model;
+
+
+class Card
+{
+    /**
+     * @var CardStyle $style @required
+     * Type of the card
+     * Valid length range: 1 - 16.
+     * Valid values: file, image, application, link, media.
+     */
+    protected $style;
+    /**
+     * @var string $description @required
+     *
+     */
+    protected $description;
+    /**
+     * @var CardFormat $format
+     * Application cards can be compact (1 to 2 lines) or medium (1 to 5 lines)
+     * Valid length range: 1 - 25.
+     * Valid values: compact, medium.
+     */
+    protected $format;
+    /**
+     * @var string $url
+     */
+    protected $url;
+    /**
+     * @var string $title @required
+     */
+    protected $title;
+    /**
+     * @var CardThumbnail $thumbnail
+     */
+    protected $thumbnail;
+    /**
+     * @var CardActivity $activity
+     */
+    protected $activity;
+    /**
+     * @var CardAttribute[] $attributes
+     */
+    protected $attributes;
+    /**
+     * @var string $id @required
+     */
+    protected $id;
+    /**
+     * @var CardIcon $icon
+     */
+    protected $icon;
+    /**
+     * @var CardImage $images
+     */
+    protected $images;
+
+    /**
+     * @return CardStyle
+     */
+    public function getStyle()
+    {
+        return $this->style;
+    }
+
+    /**
+     * @param CardStyle $style
+     */
+    public function setStyle($style)
+    {
+        $this->style = $style;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * @return CardFormat
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * @param CardFormat $format
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return CardThumbnail
+     */
+    public function getThumbnail()
+    {
+        return $this->thumbnail;
+    }
+
+    /**
+     * @param CardThumbnail $thumbnail
+     */
+    public function setThumbnail($thumbnail)
+    {
+        $this->thumbnail = $thumbnail;
+    }
+
+    /**
+     * @return CardActivity
+     */
+    public function getActivity()
+    {
+        return $this->activity;
+    }
+
+    /**
+     * @param CardActivity $activity
+     */
+    public function setActivity($activity)
+    {
+        $this->activity = $activity;
+    }
+
+    /**
+     * @return CardAttribute[]
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @param CardAttribute $attribute
+     */
+    public function addAttribute($attribute)
+    {
+        if (!isset($this->attributes)){
+            $this->attributes = array();
+        }
+        $this->attributes[] = $attribute;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return CardIcon
+     */
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @param CardIcon $icon
+     */
+    public function setIcon($icon)
+    {
+        $this->icon = $icon;
+    }
+
+    /**
+     * @return CardImage
+     */
+    public function getImages()
+    {
+        return $this->images;
+    }
+
+    /**
+     * @param CardImage $images
+     */
+    public function setImages($images)
+    {
+        $this->images = $images;
+    }
+
+    public function toArray(){
+        $result = array();
+        if ($this->style) $result['style'] = $this->style;
+        if ($this->description) $result['description'] = $this->description;
+        if ($this->format) $result['format'] = $this->format;
+        if ($this->url) $result['url'] = $this->url;
+        if ($this->title) $result['title'] = $this->title;
+        if ($this->thumbnail) $result['thumbnail'] = $this->thumbnail->toArray();
+        if ($this->activity) $result['activity'] = $this->activity;
+        if ($this->attributes) {
+            $result['attributes'] = array();
+            foreach ($this->attributes as $attribute) {
+                $result['attributes'][] = $attribute->toArray();
+            }
+        }
+        if ($this->images) $result['images'] = $this->images->toArray();
+        if ($this->id) $result['id'] = $this->id;
+        if ($this->icon) $result['icon'] = $this->icon->toArray();
+        return $result;
+    }
+
+}
+
+class CardImage {
+    /**
+     * @var string $image Image url
+     */
+    public $image;
+
+    public function toArray(){
+        $result = array();
+        if ($this->image) $result['image'] = $this->image;
+        return $result;
+    }
+}
+
+class CardAttribute {
+    /**
+     * @var CardAttributeValue $value @required
+     * @var string $label Valid length range: 1 - 50.
+     */
+    public $value;
+    public $label;
+
+    public function __construct()
+    {
+        $this->value = new CardAttributeValue();
+    }
+
+    public function toArray(){
+        $result = array();
+        if ($this->value) $result['value'] = $this->value;
+        if ($this->label) $result['label'] = $this->label;
+        return $result;
+    }
+}
+
+class CardAttributeValue {
+    /**
+     * @var string $url Url to be opened when a user clicks on the label. Valid length range: 1 - unlimited.
+     * @var AttributeValueStyle $style
+     * @var string $label
+     * @var CardIcon $icon
+     */
+    public $url;
+    public $style;
+    public $label;
+    public $icon;
+
+    public function toArray(){
+        $result = array();
+        if ($this->url) $result['url'] = $this->url;
+        if ($this->style) $result['style'] = $this->style;
+        if ($this->label) $result['label'] = $this->label;
+        if ($this->icon) $result['icon'] = $this->icon;
+        return $result;
+    }
+}
+
+/**
+ * The activity will generate a collapsable card of one line showing
+ * the html and the ability to maximize to see all the content.
+ *
+ * @package GorkaLaucirica\HipchatAPIv2Client\Model
+ */
+class CardActivity {
+    /**
+     * @var string $html Html for the activity to show in one line a summary of the action that happened
+     * Valid length range: 1 - unlimited. @required
+     * @var CardIcon $icon
+     */
+    public $html;
+    public $icon;
+
+    public function toArray(){
+        $result = array();
+        if ($this->html) $result['html'] = $this->html;
+        if ($this->icon) $result['icon'] = $this->icon;
+        return $result;
+    }
+}
+
+/**
+ * An object with the following properties.
+ * @package GorkaLaucirica\HipchatAPIv2Client\Model
+ */
+class CardIcon {
+    /**
+     * @var string $url The url where the icon is Valid length range: 1 - unlimited. @required
+     * @var string $urlat2 The url for the icon in retina. Valid length range: 1 - unlimited.
+     */
+    public $url;
+    public $urlat2;
+
+    public function toArray(){
+        $result = array();
+        if ($this->url) $result['url'] = $this->url;
+        if ($this->urlat2) $result['urlat2'] = $this->urlat2;
+        return $result;
+    }
+}
+
+/**
+ * An object with the following properties.
+ * @package GorkaLaucirica\HipchatAPIv2Client\Model
+ */
+class CardThumbnail {
+    /**
+     * @var string $url The thumbnail url. Valid length range: 1 - 250. @required
+     * @var integer $width The original width of the image
+     * @var string $urlat2 The thumbnail url in retina. Valid length range: 1 - 250.
+     * @var integer $height The original height of the image
+     */
+    public $url;
+    public $width;
+    public $urlat2;
+    public $height;
+
+    public function toArray(){
+        $result = array();
+        if ($this->url) $result['value'] = $this->url;
+        if ($this->width) $result['width'] = $this->width;
+        if ($this->urlat2) $result['urlat2'] = $this->urlat2;
+        if ($this->height) $result['height'] = $this->height;
+        return $result;
+    }
+}
+
+abstract class CardStyle {
+    const file = "file";
+    const image = "image";
+    const application = "application";
+    const link = "link";
+    const media = "media";
+}
+
+abstract class CardFormat {
+    const compact = "compact";
+    const medium = "medium";
+}
+
+abstract class AttributeValueStyle {
+    const lozenge_success = "lozenge-success";
+    const lozenge_error = "lozenge-error";
+    const lozenge_current = "lozenge-current";
+    const lozenge_complete = "lozenge-complete";
+    const lozenge_moved = "lozenge-moved";
+    const lozenge = "lozenge";
+}

--- a/Model/Message.php
+++ b/Model/Message.php
@@ -19,6 +19,8 @@ class Message
 
     protected $from = '';
 
+    protected $card;
+
 
     const COLOR_YELLOW = 'yellow';
     const COLOR_GREEN = 'green';
@@ -72,6 +74,7 @@ class Message
         $json['notify'] = $this->notify;
         $json['message_format'] = $this->messageFormat;
         $json['date'] = $this->date;
+        $json['card'] = $this->card->toArray();
 
         return $json;
 
@@ -191,5 +194,12 @@ class Message
     public function getFrom()
     {
         return $this->from;
+    }
+
+    /**
+     * @param Card $card
+     */
+    public function setCard($card){
+        $this->card = $card;
     }
 }

--- a/Model/Message.php
+++ b/Model/Message.php
@@ -74,8 +74,14 @@ class Message
         $json['notify'] = $this->notify;
         $json['message_format'] = $this->messageFormat;
         $json['date'] = $this->date;
-        $json['card'] = $this->card->toArray();
-
+        if ($this->card)
+        {
+            if ($json['message_format'] != "html")
+            {
+                $json['message_format'] = "html";
+            }
+            $json['card'] = $this->card->toArray();
+        }
         return $json;
 
     }

--- a/examples/cards.php
+++ b/examples/cards.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * This example file builds several example cards and sends them to the given Room (via $roomID), demonstrating the
+ * basic usage of the Card classes.
+ *
+ * To send each of the cards, uncomment the line:
+ * $room = $roomAPI->sendRoomNotification($roomID, $message);
+ * at the end of each card block.
+ */
+
+require_once __DIR__."/../vendor/autoload.php";
+
+$roomID = 112233;
+// See https://developer.atlassian.com/hipchat/guide/hipchat-rest-api/api-access-tokens to get your token
+$oAuthToken = '__YOUR_TOKEN__HERE__';
+
+use GorkaLaucirica\HipchatAPIv2Client\Auth\OAuth2;
+use GorkaLaucirica\HipchatAPIv2Client\Client;
+use GorkaLaucirica\HipchatAPIv2Client\Model\Message;
+use GorkaLaucirica\HipchatAPIv2Client\API\RoomAPI;
+use GorkaLaucirica\HipchatAPIv2Client\Model\Card;
+use GorkaLaucirica\HipchatAPIv2Client\Model\CardImage;
+use GorkaLaucirica\HipchatAPIv2Client\Model\CardAttribute;
+use GorkaLaucirica\HipchatAPIv2Client\Model\CardFormat;
+use GorkaLaucirica\HipchatAPIv2Client\Model\CardThumbnail;
+use GorkaLaucirica\HipchatAPIv2Client\Model\CardStyle;
+use GorkaLaucirica\HipchatAPIv2Client\Model\AttributeValueStyle;
+use GorkaLaucirica\HipchatAPIv2Client\Model\CardIcon;
+use GorkaLaucirica\HipchatAPIv2Client\Model\CardActivity;
+
+
+//All queries need the following two lines
+$auth = new OAuth2($oAuthToken);
+$client = new Client($auth);
+
+/**
+ * Direct implementations of the example cards at
+ * https://developer.atlassian.com/hipchat/guide/sending-messages#SendingMessages-UsingCards
+ */
+
+/**
+ * Card 1
+ */
+$message = new Message();
+$message->setMessage("This is a implementation of example card 1");
+$cardOne = new Card("Sample application card", CardStyle::application,
+    "This is a description of an application object.\nwith 2 lines of text");
+$cardOne->setFormat(CardFormat::medium);
+$cardOne->setUrl("https://www.application.com/an-object");
+$cardOne->setId("db797a68-0aff-4ae8-83fc-2e72dbb1a707");
+$cardOneIcon = new CardIcon("http://bit.ly/1S9Z5dF");
+$cardOne->setIcon($cardOneIcon);
+$attr1 = new CardAttribute("value1");
+$attr1->label = "attribute1";
+$attr2 = new CardAttribute("value2");
+$attr2->value->style = AttributeValueStyle::lozenge_complete;
+$attr2->value->icon = "http://bit.ly/1S9Z5dF";
+$attr2->label = "attribute2";
+$cardOne->addAttribute($attr1);
+$cardOne->addAttribute($attr2);
+$message->setCard($cardOne);
+echo json_encode($message->toJson());
+$roomAPI = new RoomAPI($client);
+//$room = $roomAPI->sendRoomNotification($roomID, $message);
+
+/**
+ * Card 2
+ */
+echo "\n\n";
+
+$message = new Message();
+$message->setMessage("This is a implementation of example card 2");
+$cardTwo = new Card("Sample application card", CardStyle::application,
+    "This is a description of an application object.\nwith 2 lines of text");
+$cardTwo->setFormat(CardFormat::medium);
+$cardTwo->setUrl("https://www.application.com/an-object");
+$cardTwo->setId("db797a68-0aff-4ae8-83fc-2e72dbb1a707");
+$cardTwoIcon = new CardIcon("http://bit.ly/1S9Z5dF");
+$cardTwo->setIcon($cardTwoIcon);
+$attr1 = new CardAttribute("value1");
+$attr1->label = "attribute1";
+$attr2 = new CardAttribute("value2");
+$attr2->value->style = AttributeValueStyle::lozenge_complete;
+$attr2->value->icon = "http://bit.ly/1S9Z5dF";
+$attr2->label = "attribute2";
+$cardTwo->addAttribute($attr1);
+$cardTwo->addAttribute($attr2);
+$activity = new CardActivity("This is a notification about <b>an object</b>");
+$cardTwo->setActivity($activity);
+$message->setCard($cardTwo);
+echo json_encode($message->toJson());
+$roomAPI = new RoomAPI($client);
+//$room = $roomAPI->sendRoomNotification($roomID, $message);
+
+/**
+ * Card 3
+ */
+echo "\n\n";
+
+$message = new Message();
+$message->setMessage("This is a implementation of example card 3");
+$cardThree = new Card("Sample image card", CardStyle::image, null);
+$cardThree->setUrl("http://bit.ly/1TmKuKQ");
+$cardThree->setId("172fe15d-d72e-4f78-8712-0ec74e7f9aa3");
+$tempImage = new CardThumbnail("http://bit.ly/1TmKuKQ");
+$tempImage->urlat2 = "http://bit.ly/1TmKuKQ";
+$tempImage->height = 1193;
+$tempImage->width = 564;
+$cardThree->setThumbnail($tempImage);
+$message->setCard($cardThree);
+echo json_encode($message->toJson());
+$roomAPI = new RoomAPI($client);
+//$room = $roomAPI->sendRoomNotification($roomID, $message);
+
+/**
+ * Card 4
+ */
+echo "\n\n";
+
+$message = new Message();
+$message->setMessage("This is a implementation of example card 4");
+$cardFour = new Card("Sample link card", CardStyle::link,
+    "This is some information about the link shared.\nin 2 lines of text");
+$cardFour->setUrl("http://www.website.com/some-article");
+$cardFour->setId("172fe15d-d72e-4f78-8712-0ec74e7f9aa3");
+$tempImage = new CardThumbnail("http://bit.ly/1TmKuKQ");
+$tempImage->urlat2 = "http://bit.ly/1TmKuKQ";
+$tempImage->height = 1193;
+$tempImage->width = 564;
+$cardFour->setThumbnail($tempImage);
+$tempIcon = new CardIcon("http://bit.ly/1Qrfs1M");
+$cardFour->setIcon($tempIcon);
+$message->setCard($cardFour);
+echo json_encode($message->toJson());
+$roomAPI = new RoomAPI($client);
+//$room = $roomAPI->sendRoomNotification($roomID, $message);
+
+/**
+ * Card 5
+ */
+echo "\n\n";
+
+$message = new Message();
+$message->setMessage("This is a implementation of example card 5");
+$cardFive = new Card("Sample media card. Click me.", CardStyle::media,
+    "Click on the title to open the image in the HipChat App");
+$cardFive->setUrl("https://s3.amazonaws.com/uploads.hipchat.com/6/26/z6i8a5djb9mvq7m/bonochat.png");
+$cardFive->setId("6492f0a6-9fa0-48cd-a3dc-2b19a0036e99");
+$tempImage = new CardThumbnail("https://s3.amazonaws.com/uploads.hipchat.com/6/26/z6i8a5djb9mvq7m/bonochat.png");
+$tempImage->urlat2 = "https://s3.amazonaws.com/uploads.hipchat.com/6/26/z6i8a5djb9mvq7m/bonochat.png";
+$tempImage->height = 3313;
+$tempImage->width = 577;
+$cardFive->setThumbnail($tempImage);
+$message->setCard($cardFive);
+echo json_encode($message->toJson());
+$roomAPI = new RoomAPI($client);
+//$room = $roomAPI->sendRoomNotification($roomID, $message);
+
+echo "\n\n";
+
+/**
+ * Some extra cards
+ */
+
+/**
+ * This is the nearly biggest card that one can generate
+ */
+$message = new Message();
+$card = new Card("A Giant Card", CardStyle::application, "This is a very large card with\ntwo lines.");
+$card->setFormat(CardFormat::medium);
+$card->setUrl("https://www.hipchat.com/docs/apiv2/");
+$cardIcon = new \GorkaLaucirica\HipchatAPIv2Client\Model\CardIcon(
+    "http://d39kbiy71leyho.cloudfront.net/wp-content/uploads/2016/05/09170020/cats-politics-TN.jpg");
+$cardIcon->urlat2 = "http://d39kbiy71leyho.cloudfront.net/wp-content/uploads/2016/05/09170020/cats-politics-TN.jpg";
+$card->setIcon($cardIcon);
+$thumbnail = new \GorkaLaucirica\HipchatAPIv2Client\Model\CardThumbnail(
+    "http://d39kbiy71leyho.cloudfront.net/wp-content/uploads/2016/05/09170020/cats-politics-TN.jpg");
+$image = new \GorkaLaucirica\HipchatAPIv2Client\Model\CardImage(
+    "https://i.ytimg.com/vi/56ucT_Hw4bg/hqdefault.jpg");
+$card->setImages($image);
+
+$tempIcon = new CardIcon("http://d39kbiy71leyho.cloudfront.net/wp-content/uploads/2016/05/09170020/cats-politics-TN.jpg");
+$tempIcon->urlat2 = "http://d39kbiy71leyho.cloudfront.net/wp-content/uploads/2016/05/09170020/cats-politics-TN.jpg";
+$card->setIcon($tempIcon);
+
+//Add some attributes
+$tempAttribute = new CardAttribute("Suit");
+$tempAttribute->label = "Clothing Type";
+$tempAttribute->value->style = AttributeValueStyle::lozenge_complete;
+$card->addAttribute($tempAttribute);
+$tempAttribute = new CardAttribute("White");
+$tempAttribute->label = "Background Color";
+$attrIcon = new CardIcon("http://bit.ly/1S9Z5dF");
+$tempAttribute->value->icon = $attrIcon;
+$card->addAttribute($tempAttribute);
+
+$message->setCard($card);
+
+$message->setMessageFormat("text");
+$message->setMessage("You don't appear to be on a client that supports Cards. But rest asured this would have been a
+big card");
+echo json_encode($message->toJson());
+
+$roomAPI = new RoomAPI($client);
+//$room = $roomAPI->sendRoomNotification($roomID, $message);
+
+echo "\n\n";
+/**
+ * An Image Card
+ */
+$message = new Message();
+$message->setMessage("This is a image card.");
+$card = new Card("An Image Card", CardStyle::image, "This is simply an image card.");
+$tempImage = new CardThumbnail("http://purrfectcatbreeds.com/wp-content/uploads/2014/06/persian-cat7.jpg");
+$tempImage->urlat2 = "http://purrfectcatbreeds.com/wp-content/uploads/2014/06/persian-cat7.jpg";
+$tempImage->height = 500;
+$tempImage->width = 500;
+$card->setThumbnail($tempImage);
+$card->setUrl("https://hipchat.com");
+$message->setCard($card);
+echo json_encode($message->toJson());
+$roomAPI = new RoomAPI($client);
+//$room = $roomAPI->sendRoomNotification($roomID, $message);
+


### PR DESCRIPTION
HipChat allows for Card objects to be added to a message in order to create a more rich experience in the Web and Desktop clients. I've added a couple helper classes to the library to accommodate these types of messages.

More on Cards can be found at [the Developer Guide](https://developer.atlassian.com/hipchat/guide/sending-messages#SendingMessages-UsingCards) (detailed information at [the API Documentation](https://www.hipchat.com/docs/apiv2/method/send_room_notification)) 

This addition only adds 18 lines in the existing library (all in Model/Message.php) and Card objects are only created by the user so it shouldn't have too big of an impact.

I created examples/cards.php with examples of each type of card demonstrated in the Developer Guide to serve as basic documentation and for testing. I don't have any experience with phpSpec but creation of tests using the example file and the final [message JSON for the cards](http://paste.nerds.io/raw/iyiruqeqok) should be straightforward.