### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Hipchat v2 Api Client
+# Hipchat v2 Api Client
 
 PHP Library to process calls to Hipchat's v2 REST API
 
@@ -12,14 +12,14 @@ PHP Library to process calls to Hipchat's v2 REST API
 
 *This package is work in progress and some functionality is not available yet.*
 
-##Installation
+## Installation
 
 The recommended way to install Hipchatv2ApiClient is through [Composer](https://getcomposer.org).
 To install this library, run the command below and you will get the latest version:
 
     composer require gorkalaucirica/hipchat-v2-api-client
     
-##Usage
+## Usage
 
 All queries need the following two lines. The first one is to authenticate yourself and the second one creates a
 client that is used by the API classes to perform requests to the API. That is enough to start, now check the API calls
@@ -31,55 +31,55 @@ section to see how to use the `$client` to send requests to the API.
     $auth = new OAuth2('tokenYouCanGetInHipchatSite');
     $client = new Client($auth);
     
-##Client for private instances
+## Client for private instances
 
 After version 1.5.0 you can set the URL in the constructor to change the base url used by the client (by default uses 
 `https://api.hipchat.com`
 
     $client = new Client($auth, null, 'https.//api.yourdomain.com');
 
-##API calls
+## API calls
 
 All API call methods are located in the API folder. All of them have been documented and all have a link to Hipchat v2
 API documentation. Some examples:
 
-####Getting user by mention name:
+#### Getting user by mention name:
 
     use GorkaLaucirica\HipchatAPIv2Client\API\UserAPI;
 
     $userAPI = new UserAPI($client);
     $user = $userAPI->getUser('@gorkalaucirica');
 
-####Getting all rooms
+#### Getting all rooms
     
     use GorkaLaucirica\HipchatAPIv2Client\API\RoomAPI;
 
     $roomAPI = new RoomAPI($client);
     $room = $roomAPI->getRooms(array('max-results' => 30));
 
-##Current status
+## Current status
 
 The following list shows methods available and missing:
 
-####Add ons
+#### Add ons
 - [ ] Get addon installable data
 - [ ] Create addon link
 - [ ] Invoke addon link
 - [ ] Delete addon link
 
-####Capabilities
+#### Capabilities
 - [ ] Get capabilities
 
-####Emoticons
+#### Emoticons
 - [ ] Get emoticon
 - [ ] Get all emoticons
 
-####OAuth Sessions
+#### OAuth Sessions
 - [ ] Generate token
 - [ ] Get session
 - [ ] Delete session
 
-####Rooms
+#### Rooms
 - [x] Get all rooms
 - [x] Create room
 - [x] Get room
@@ -107,7 +107,7 @@ The following list shows methods available and missing:
 - [x] Get all webhooks
 - [x] Create webhook
 
-####Users
+#### Users
 - [x] Get all users
 - [x] Create user
 - [x] View user


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
