### PR TITLE
room-tojson-fails-when-rooom-doesnt-have-owner

### DIFF
--- a/Model/Room.php
+++ b/Model/Room.php
@@ -93,8 +93,8 @@ class Room
             $json['is_archived'] = $this->isArchived();
             $json['is_guest_accessible'] = $this->isGuestAccessible();
             $json['topic'] = $this->getTopic();
-            $json['owner'] = array('id' => $this->getOwner()->getId());
-        } else { //Paramters for POST call
+            $json['owner'] = is_null($this->getOwner()) ? null : $this->getOwner()->toJson();
+        } else { //Parameters for POST call
             $json['guest_access'] = $this->isGuestAccessible();
             if ($this->getOwner()) {
                 $json['owner_user_id'] = $this->getOwner()->getId();

--- a/Model/User.php
+++ b/Model/User.php
@@ -83,6 +83,7 @@ class User
     public function toJson()
     {
         $json = array();
+        $json['id'] = $this->id;
         $json['name'] = $this->name;
         $json['title'] = $this->title;
         $json['mention_name'] = $this->mentionName;


### PR DESCRIPTION
Added id to the `User`'s `toJson`, and replaced call to `getId()` for the owner in `Room`'s `toJson` with a null check.

 This means that `toJson` can be called on a `Room` regardless of if it has an owner or not (since rooms returned by get_all_rooms don't have their owners included in the return).

By adding the `id` field to `User`'s `toJson`, the api remains backwards compatible, since the `id` field remains.